### PR TITLE
Added 'keep-together.within-page' on 'fig-box' attribute set.

### DIFF
--- a/xslt/main/jats-xslfo.xsl
+++ b/xslt/main/jats-xslfo.xsl
@@ -513,7 +513,9 @@ CHANGES TO NLM JATS v3.0 stylesheet        (wap) v1.0 (2009-12-08)
 
 <xsl:attribute-set name="chem-struct-inline"/>
 
-<xsl:attribute-set name="fig-box" use-attribute-sets="box"/>
+<xsl:attribute-set name="fig-box" use-attribute-sets="box">
+  <xsl:attribute name="keep-together.within-page">10</xsl:attribute>
+</xsl:attribute-set>
 
 <xsl:attribute-set name="fig" use-attribute-sets="panel"/>
 


### PR DESCRIPTION
When figures aren't floated, it's possible that the box enclosing a graphic and caption can break across a page.

This is a simple workaround specific to figure handling.  You may want to instead apply this to the 'box' attribute set so it also applies in other contexts.

It doesn't impact floated figures since fo:float doesn't break across pages anyway.
