### PR TITLE
Fix links to github ncbi organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
-###[JATSPreviewStylesheets on Github Pages](http://ncbitools.github.com/JATSPreviewStylesheets/)
+## [JATSPreviewStylesheets on Github Pages](http://ncbi.github.com/JATSPreviewStylesheets/)
 
-The [JATSPreviewStylesheets page](http://ncbitools.github.com/JATSPreviewStylesheets/) on [Github Pages](http://pages.github.com) offers a quick, easy way to download the most recent version of the [JATSPreviewStylesheets](https://github.com/NCBITools/JATSPreviewStylesheets).
+The [JATSPreviewStylesheets page](http://ncbi.github.com/JATSPreviewStylesheets/) on [Github 
+Pages](http://pages.github.com) offers a quick, easy way to download the most recent version of 
+the [JATSPreviewStylesheets](https://github.com/ncbi/JATSPreviewStylesheets).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-## [JATSPreviewStylesheets on Github Pages](http://ncbi.github.com/JATSPreviewStylesheets/)
+## [JATSPreviewStylesheets on Github Pages](http://ncbi.github.io/JATSPreviewStylesheets/)
 
-The [JATSPreviewStylesheets page](http://ncbi.github.com/JATSPreviewStylesheets/) on [Github 
+The [JATSPreviewStylesheets page](http://ncbi.github.io/JATSPreviewStylesheets/) on [Github 
 Pages](http://pages.github.com) offers a quick, easy way to download the most recent version of 
 the [JATSPreviewStylesheets](https://github.com/ncbi/JATSPreviewStylesheets).

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 
 		<link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
 
-		<title>JATSPreviewStylesheets - a project of NCBITools</title>
+		<title>JATSPreviewStylesheets - a project of NCBI</title>
 	</head>
 	
 	<body>
@@ -16,13 +16,13 @@
 		<!-- HEADER -->
 		<div id="header_wrap" class="outer">
 			<header class="inner">
-				<a id="forkme_banner" href="https://github.com/NCBITools/JATSPreviewStylesheets">View on GitHub</a>
+				<a id="forkme_banner" href="https://github.com/ncbi/JATSPreviewStylesheets">View on GitHub</a>
 
 				<h1 id="project_title">JATSPreviewStylesheets</h1>
 				<h2 id="project_tagline"></span></h2>
 
 				<section id="downloads">
-					<a class="zip_download_link" href="https://github.com/NCBITools/JATSPreviewStylesheets/zipball/release.2012-10-12">Download this version as a .zip file</a>
+					<a class="zip_download_link" href="https://github.com/ncbi/JATSPreviewStylesheets/zipball/release.2012-10-12">Download this version as a .zip file</a>
 				</section>
  			</header>
 		</div>
@@ -32,7 +32,7 @@
 			<section id="main_content" class="inner">
 				<h1><a name="dtdanalyzer" class="anchor" href="#dtdanalyzer"><span class="mini-icon mini-icon-link"></span></a>JATSPreviewStylesheets</h1>
 
-			  <p>The github site for this project is at : <a href="https://github.com/NCBITools/JATSPreviewStylesheets">https://github.com/NCBITools/JATSPreviewStylesheets</a></p>
+			  <p>The github site for this project is at : <a href="https://github.com/ncbi/JATSPreviewStylesheets">https://github.com/ncbi/JATSPreviewStylesheets</a></p>
 
 			  <p>This work is in the public domain and may be reproduced, published or 
 			  otherwise used without the permission of the National Library of Medicine (NLM).</p>
@@ -51,7 +51,7 @@
 		<!-- FOOTER  -->
 		<div id="footer_wrap" class="outer">
 			<footer class="inner">
- 				<p class="copyright">JATSPreviewStylesheets maintained by <a href="https://github.com/NCBITools">NCBITools</a></p>
+ 				<p class="copyright">JATSPreviewStylesheets maintained by <a href="https://github.com/ncbi">ncbi</a></p>
 				<p>Published with <a href="http://pages.github.com">GitHub Pages</a> using the <a href="https://github.com/jsncostello/slate">Slate Theme</a></p>
 			</footer>
 		</div>


### PR DESCRIPTION
We recently changed our NCBI github from a user account (NCBITools) to an organization (ncbi).  I just noticed that this repo's gh pages point to the old location.
